### PR TITLE
Log exception in tick to player

### DIFF
--- a/engine/src/game/world.ts
+++ b/engine/src/game/world.ts
@@ -6,6 +6,7 @@ import { type DungeonBuilderOptions } from "../generation/builder.ts";
 import { RNG, Deck } from "./random.ts";
 import { Player } from "./player.ts";
 import { WorldMap } from "./map.ts";
+import { LogLevel } from "../core/logger.ts";
 
 export enum GameState {
 	Setup,
@@ -262,6 +263,7 @@ export class World extends EventTarget {
 				try {
 					move = await player.tickTurn(circumstances, visualTick);
 				} catch (error) {
+					player.coordinator.logger(LogLevel.Error, "Exception in player tick");
 					console.error("Exception in player tick:", error);
 					player.lastMoveStatus = CoreMsg.MoveResult.Error;
 					continue;


### PR DESCRIPTION
## What
When a bot tick method throws an exception this now shows in that bots log/console thingy.

## Why
When i was trying to make my own bot it took me a good minute before i realized nothing happened because my code panicked, this should improve that.